### PR TITLE
ResetDataBase

### DIFF
--- a/db/migrate/20200808093630_create_products.rb
+++ b/db/migrate/20200808093630_create_products.rb
@@ -7,7 +7,6 @@ class CreateProducts < ActiveRecord::Migration[5.2]
       t.integer :price, null:false
       t.integer :trading_status, null:false
       t.datetime :completed_at
-      t.references :category, null: false, foreign_key: true
       t.references :shipping, null: false, foreign_key: true
       t.references :brand, foreign_key:true
       t.references :user, null: false, foreign_key: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_07_065648) do
+ActiveRecord::Schema.define(version: 2020_08_08_093630) do
 
   create_table "brands", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.text "path", null: false
-    t.string "name", null: false
-    t.string "ancestry"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -33,14 +25,12 @@ ActiveRecord::Schema.define(version: 2020_08_07_065648) do
     t.integer "price", null: false
     t.integer "trading_status", null: false
     t.datetime "completed_at"
-    t.bigint "category_id", null: false
     t.bigint "shipping_id", null: false
     t.bigint "brand_id"
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["brand_id"], name: "index_products_on_brand_id"
-    t.index ["category_id"], name: "index_products_on_category_id"
     t.index ["shipping_id"], name: "index_products_on_shipping_id"
     t.index ["user_id"], name: "index_products_on_user_id"
   end
@@ -66,7 +56,6 @@ ActiveRecord::Schema.define(version: 2020_08_07_065648) do
   end
 
   add_foreign_key "products", "brands"
-  add_foreign_key "products", "categories"
   add_foreign_key "products", "shippings"
   add_foreign_key "products", "users"
 end


### PR DESCRIPTION
Mysql2::Error: Cannot add foreign key constraintが出てデプロイに失敗するため、修正

下記記述削除
t.references :category, null: false, foreign_key: true

ファイル名を変更してマイグレーションファイルの順番を変更

20200804093630_create_products.rb
↓
20200808093630_create_products.rb