### PR TITLE
Change_ColumnName,Assosiation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+/public/uploads/*

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 - belongs_to :user
 - belongs_to :category
 - belongs_to :brand
-- has_one :shipping
+- belongs_to :shipping
 - has_one :order
 - has_many :product_images
 
@@ -94,8 +94,7 @@
 |------|----|-------|
 |area|string|null: false|
 |fee|integer|null: false|
-|type|string|null: false|
+|shipping_type|string|null: false|
 |handling_time|integer|null: false|
-|product_id|references|null: false, foreign_key: true|
 ### Association
-- belongs_to :product
+- has_one :product


### PR DESCRIPTION
# What
### ■ProductとShippingのアソシエーションを変更
【正】
・productsテーブル
belongs_to :shipping

・shippingsテーブル
has_one :product

### ■Shippingsテーブルからproduct_idのカラムを削除

### ■Shippingsテーブルのtypeカラムの名前変更
type→shipping_type

# Why
商品出品機能実装にあたって、DB設計の間違いに気がついたため。
"type"というカラムをもつテーブルに接続し、取得系のメソッドを呼ぶとActiveRecord::SubclassNotFoundエラーが出るため