### PR TITLE
Fix toppage

### DIFF
--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -4,7 +4,7 @@ window.addEventListener('DOMContentLoaded', function(){
   let submit = document.getElementById("payment_card_submit-button");
   Payjp.setPublicKey('pk_test_5ef47dbae89fcfc8309d0276'); 
 
-    submit.addEventListener('click', function(e){ 
+    submit.addEventListener('click', function(e){
 
     e.preventDefault(); 
 

--- a/app/assets/stylesheets/module/_new.scss
+++ b/app/assets/stylesheets/module/_new.scss
@@ -1,4 +1,5 @@
 .card_add{
+  height: 100vh;
   display: block;
   width: 700px;
   padding: 24px 0px;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,7 @@ class UsersController < ApplicationController
   end
 
   def show
-    
+    @parents = Category.where(ancestry: nil)
   end
   
 end

--- a/app/views/categories/index.html.haml
+++ b/app/views/categories/index.html.haml
@@ -19,3 +19,4 @@
                       %li.grandchildren= link_to "#{grandchild.name}", category_path(grandchild)
 
   = render "home/footer"
+  = render "home/camera-btn"  

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -30,3 +30,4 @@
                   .p (税込)
           = paginate @products
   = render "home/footer"
+  = render "home/camera-btn"  


### PR DESCRIPTION
#what
・カテゴリーのページにも出品ボタンを付与。
・クレジットカード登録ページ下部の空白を削除
#why
・カテゴリーページからも出品できるようにするため。
・サイトとしての見た目を整えるため。

【クレジットカード登録ページ】
https://gyazo.com/776e4d814a588ed5b29064f69bc6eba3

【カテゴリページ】
https://gyazo.com/39b229de3b8ccab2d662663f5b7ffba1