### PR TITLE
Fix showing only first img at index and categories

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,7 @@
 class HomeController < ApplicationController
   def index
-    @images = ProductImage.order("created_at DESC").page(params[:page]).per(5)
-    @products = Product.order("created_at DESC").page(params[:page]).per(5)
+    @images = ProductImage.order("created_at DESC").limit(5)
+    @products = Product.order("created_at DESC").limit(5)
     @parents = Category.where(ancestry: nil)
   end
 end

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -14,12 +14,11 @@
               - category = Category.find(product.category_id)
               = link_to product_path(id: product.id), class: "category__product" do
                 .category__product--img
-                  - product.product_images.each do |image|
-                    = image_tag image.image_url.url, class: "img"
-                      - if product.order.present?
-                      .sold__box
-                        .sold__box--text
-                          SOLD
+                  = image_tag product.product_images.first.image_url.url, class: "img"
+                    - if product.order.present?
+                    .sold__box
+                      .sold__box--text
+                        SOLD
                 .category__product--details
                   .product__name= product.name
                   %ul

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -93,12 +93,11 @@
           - category = Category.find(product.category_id)
           = link_to product_path(id: product.id), class: "category__product" do
             .category__product--img
-              - product.product_images.each do |image|
-                = image_tag image.image_url.url, class: "img"
-                  - if product.order.present?
-                  .sold__box
-                    .sold__box--text
-                      SOLD
+              = image_tag product.product_images.first.image_url.url, class: "img"
+                - if product.order.present?
+                .sold__box
+                  .sold__box--text
+                    SOLD
             .category__product--details
               .product__name= product.name
               %ul
@@ -116,12 +115,11 @@
           - category = Category.find(product.category_id)
           = link_to product_path(id: product.id), class: "category__product" do
             .category__product--img
-              - product.product_images.each do |image|
-                = image_tag image.image_url.url, class: "img"
-                  - if product.order.present?
-                  .sold__box
-                    .sold__box--text
-                      SOLD
+              = image_tag product.product_images.first.image_url.url, class: "img"
+                - if product.order.present?
+                .sold__box
+                  .sold__box--text
+                    SOLD
             .category__product--details
               .product__name= product.name
               %ul


### PR DESCRIPTION
# What
- 2枚以上の画像が保存されている場合、全ての画像が重なってサムネイル表示される為修正

# Why
- UIの向上

# Imgs
https://gyazo.com/39fb1adcccbbcc79405a09d3a1cecdbf
https://gyazo.com/69bcbc3953546cf17bed66b305ec9fd4
https://gyazo.com/989ec02047b71c2e6d8ba2a163aaccb8