### PR TITLE
ログイン画面とユーザー登録画面の修正

### DIFF
--- a/app/assets/stylesheets/module/login.scss
+++ b/app/assets/stylesheets/module/login.scss
@@ -1,24 +1,18 @@
 * {
   box-sizing: border-box;
 }
-
 a {
   text-decoration: none;
   // color: white;
   // margin: 5px;
 }
-
-
-
-.header1 {
+.header-login {
   height: 100px;
   margin: auto;
   text-align: center;
-  margin-top: 100px;
+  padding-top: 100px;
   margin-bottom: 100px;
-
 }
-
 .login-form__text {
   color: #3CCACE;
   font-size: 40px;
@@ -27,11 +21,8 @@ a {
   padding-bottom: 50px;;
   text-align: center;
   border-bottom: 1px solid white;
-
 }
-
 .field-sessions {
-
   font-size: 15px;
   font-family: monospace;
   background-color:#EEE;
@@ -40,11 +31,8 @@ a {
   padding: 30px;
   margin: auto;
   margin-bottom: 200px;
-
 }
-  
   .field-mail {
-  
     font-size: 20px;
     font-family: monospace;
     background-color:#EEE;
@@ -54,11 +42,8 @@ a {
     margin: auto;
     margin-top: 100px;
     margin-bottom: 100px;
-    
   }
-  
   .field-pass {
-
     font-size: 20px;
     font-family: monospace;
     background-color:#EEE;
@@ -68,11 +53,7 @@ a {
     margin: auto;
     margin-bottom: 200px;
   }
-
-
-
   .btn-log {
-
     font-family: monospace;
     display: inline-block;
     border-radius: 5%;
@@ -80,45 +61,15 @@ a {
     text-align: center;
     cursor: pointer;
     padding: 13px 100px;
-    background: #ff0000;
+    background: #3CCACE;
     color: #ffffff;
     line-height: 1em; 
     transition: .3s;
-    border: 2px solid #ff0000;
+    border: 2px solid #3CCACE;
     margin-bottom: 100px;
-
   }
   .pass-forgot {
   a {
     color:  #3CCACE;
-
   }
   }
-
-
-
-.footer2 {
-  background-color: #272727;
-  height: 200px;
-
-  a {
-    text-decoration: none;
-    color: white;
-    margin: 5px;
-  }
-  
-  &__info {
-    text-align: center;
-    text-decoration: none;
-    color: white;
-    padding-top: 30px;
-  }
-
-  &__logo {
-    text-align: center;
-    font-size: 15px;
-    color: white;
-    padding-top: 30px;
-  }
-
-}

--- a/app/assets/stylesheets/module/new_user.scss
+++ b/app/assets/stylesheets/module/new_user.scss
@@ -1,17 +1,11 @@
 
 
-
-
 .header_logo {
   margin: auto;
   text-align: center;
   padding-top: 50px;
-  
 }
-
-
 .header_text1 {
-
   font-size: 40px;
   color: #3CCACE;
   font-family: monospace;
@@ -19,7 +13,6 @@
   padding-top: 100px;
   padding-bottom: 100px;
 }
-
 .label-must {
   width: 40px;
   background-color: red;
@@ -31,9 +24,7 @@
   margin-bottom: 20px;
   margin-top: 30px;
 }
-
 .field-all {
-
 font-size: 20px;
 font-family: monospace;
 background-color:#EEE;
@@ -44,9 +35,7 @@ margin-bottom: 200px;
 margin: auto;
 margin-bottom: 200px;
 }
-
 .field-nick {
-
   width: 500px;
   margin: auto;
   font-size: 20px;
@@ -54,23 +43,8 @@ margin-bottom: 200px;
   background-color:#EEE;
   text-align: center;
   padding: 20px;
-  
 }
-
 .field-name {
-
-  width: 600px;
-  font-size: 20px;
-  font-family: monospace;
-  background-color:#EEE;
-  text-align: center;
-  padding: 30px;
-  margin: auto;
-
-}
-
-.field-kana {
-
   font-size: 20px;
   font-family: monospace;
   background-color:#EEE;
@@ -78,10 +52,20 @@ margin-bottom: 200px;
   width: 550px;
   padding: 30px;
   margin: auto;
+  display: flex;
+  margin-left: 90px;
 }
-
+.field-kana {
+  font-size: 20px;
+  font-family: monospace;
+  background-color:#EEE;
+  text-align: center;
+  width: 600px;
+  padding: 30px;
+  margin: auto;
+  display: flex;
+}
 .field-email {
-
   font-size: 20px;
   font-family: monospace;
   background-color:#EEE;
@@ -90,9 +74,7 @@ margin-bottom: 200px;
   padding: 30px;
   margin: auto;
 }
-
 .field-birth {
-
   font-size: 20px;
   font-family: monospace;
   background-color:#EEE;
@@ -101,9 +83,7 @@ margin-bottom: 200px;
   padding: 30px;
   margin: auto;
 }
-
 .field-password {
-
   font-size: 20px;
   font-family: monospace;
   background-color:#EEE;
@@ -112,9 +92,7 @@ margin-bottom: 200px;
   padding: 30px;
   margin: auto;
 }
-
 .field-pass2 {
-
   font-size: 20px;
   font-family: monospace;
   background-color:#EEE;
@@ -124,8 +102,6 @@ margin-bottom: 200px;
   margin: auto;
   margin-bottom: 200px;
 }
-
-
 .button-regi { 
   font-family: monospace;
   display: inline-block;
@@ -134,36 +110,10 @@ margin-bottom: 200px;
   text-align: center;
   cursor: pointer;
   padding: 13px 100px;
-  background: #ff0000;
+  background: #3CCACE;
   color: #ffffff;
   line-height: 1em; 
   transition: .3s;
-  border: 2px solid #ff0000;
+  border: 2px solid #3CCACE;
   margin-bottom: 100px;
-
- 
-}
-
-
-.footer1 {
-  background-color: #272727;
-  a {
-  text-decoration: none;
-  color: white;
-  margin: 5px;
-  }
-  
-  &__info {
-    text-align: center;
-    text-decoration: none;
-    color: white;
-    padding-top: 30px;
-  }
-
-  &__logo {
-    text-align: center;
-    font-size: 15px;
-    color: white;
-    padding-top: 30px;
-  }
 }

--- a/app/controllers/new_user_controller.rb
+++ b/app/controllers/new_user_controller.rb
@@ -2,10 +2,8 @@ class NewUserController < ApplicationController
   def index
     @users = User.all
   end
-
   private
-
   def user_params
-    params.require(:user).permit(:nickname, :email)
+    params.require(:user).permit(:nickname,:family_name,:first_name,:family_name_kana,:first_name_kana,:email,:birthday,:password)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,33 +5,30 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   validates :nickname, presence: true, uniqueness: true
+  VALID_family_name_REGEX =/\A[ぁ-んァ-ン一-龥]/
 
-
-  VALID_family_name_REGEX =/\A[一-龥ぁ-ん]/
   validates :family_name, {presence: true,format: { with: VALID_family_name_REGEX,message: "は全角で入力して下さい"}}
- 
+  VALID_first_name_REGEX =/\A[ぁ-んァ-ン一-龥]/
 
-  VALID_first_name_REGEX =/\A[一-龥ぁ-ん]/
   validates :first_name, {presence: true,format: { with: VALID_first_name_REGEX,message: "は全角で入力して下さい"}}
-
   VALID_family_name_kana_REGEX =/\A[ァ-ヶー－]+\z/
+
   validates :family_name_kana, {presence: true,format: { with: VALID_family_name_kana_REGEX,message: "は全角カタカナのみで入力して下さい"}}
-
-
   VALID_first_name_kana_REGEX =/\A[ァ-ヶー－]+\z/
+
   validates :first_name_kana, {presence: true,format: { with: VALID_first_name_kana_REGEX,message: "は全角カタカナのみで入力して下さい"}}
-
   VALID_birth_REGEX=/\A[0-9０-９]+\z/
-  validates :birth, length: { is: 8 ,presence: true,format: { with: VALID_birth_REGEX,message: "は西暦から数字８桁で入力して下さい"}}
 
+  validates :birth, presence: true
   VALID_PASSWORD_REGEX =/\A(?=.*?[a-z])(?=.*?[A-Z])(?=.*?[\d])\w{7,12}\z/
-  validates :password, {presence: true,format: { with: VALID_PASSWORD_REGEX,message: "は半角7~12文字英大文字・小文字・数字それぞれ１文字以上含む必要があります"}}
 
+  validates :password, {presence: true,format: { with: VALID_PASSWORD_REGEX,message: "は半角7~12文字英大文字・小文字・数字それぞれ１文字以上含む必要があります"}}
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+
   validates :email, {presence: true, format: { with: VALID_EMAIL_REGEX }, uniqueness: { case_sensitive: false }}
   
   has_many :products
   has_many :orders
   has_one :delivery_address
-  has_one :credit_card
+  has_one :credit_card, dependent: :destroy
 end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,9 +1,6 @@
-
 .header
-
 .header_logo
   = link_to image_tag("logo.png",class: "furima-logo",size:'300x100'),"/"
-
 .header_text1 会員登録
 = form_with model: @user, url: user_registration_path, id: 'new_user', class: 'new_user', local: true do |f|
   = render "devise/shared/error_messages", resource: resource
@@ -13,45 +10,38 @@
       = f.label 'ニックネーム'
       %br/
       = f.text_field :nickname, autofocus: true, autocomplete: "nickname",size:"20x5"
-
     %br/
     .label-must 必須
     .field-name
       = f.label '姓'
-      = f.text_field :family_name,autofocus: true, autocomplete: "family_name",size: "12x1"
+      = f.text_field :family_name,autofocus: true, autocomplete: "family_name",size: "15x1"
       = f.label '名'
-      = f.text_field :first_name,autofocus: true, autocomplete: "first_name",size: "12x1"
-
+      = f.text_field :first_name,autofocus: true, autocomplete: "first_name",size: "15x1"
     %br/
     .label-must 必須
     .field-kana
       = f.label '姓（カナ）'
-      = f.text_field :family_name_kana,autofocus: true, autocomplete: "family_name_kana",size: "12x1"
+      = f.text_field :family_name_kana,autofocus: true, autocomplete: "family_name_kana",size: "15x1"
       = f.label '名（カナ）'
-      = f.text_field :first_name_kana,autofocus: true, autocomplete: "first_name_kana",size: "12x1"
-
+      = f.text_field :first_name_kana,autofocus: true, autocomplete: "first_name_kana",size: "15x1"
     %br/
     .label-must 必須
     .field-email
       = f.label 'メールアドレス'
       %br/
       = f.email_field :email, autofocus: true, autocomplete: "email",size:"40x5"
-
     %br/
     .label-must 必須
     .field-birth
-      = f.label '生年月日（西暦から数字8桁）'
+      = f.label '生年月日'
       %br/
-      = f.text_field :birth, autofocus: true, autocomplete: "birth",size:"20x5"
-
-
+      = f.date_select :birth,prompt:"--", use_month_numbers: true,start_year: 1950, end_year: (Time.now.year - 10)
     %br/
     .label-must 必須
     .field-password
       = f.label 'パスワード（７文字以上）'
       %br/
       = f.password_field :password, autocomplete: "new-password",size:"20x5"
-
     %br/
     .label-must 必須
     .field-pass2
@@ -60,13 +50,4 @@
       = f.password_field :password_confirmation, autocomplete: "new-password",size:"20x5"
     .actions
       = f.submit "登録" , class: "button-regi"
-
-
-.footer1
-  .footer1__info
-    = link_to 'プライバシーポリシー',''
-    = link_to 'フリマ利用規約',''
-    = link_to '特定商取引に関する表記',''
-  .footer1__logo
-    = link_to image_tag("logo-white.png", class: "furima-white-logo",size:'200x50'), root_path
-    %p © FURIMA
+= render "home/footer"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,10 +1,7 @@
 #login
-
-.header1
+.header-login
   = link_to image_tag("logo.png",class: "furima-logo",size:'300x100'),"/"
-
 .login-form__text ログイン
-
 = form_with model: @user, url: user_session_path, id: 'login_user', class: 'login_user', local: true do |f|
   .field-sessions
     .field-mail
@@ -21,15 +18,6 @@
         = f.password_field :password, autocomplete: "off",size:"35x10"
     .actions
       = f.submit "ログイン", class: 'btn-log'
-    .pass-forgot 
+    .pass-forgot
       = link_to "*パスワードを忘れた方はこちら"
-    
-
-.footer2
-  .footer2__info
-    = link_to 'プライバシーポリシー','/'
-    = link_to 'フリマ利用規約','/'
-    = link_to '特定商取引に関する表記','/'
-  .footer2__logo
-    = link_to image_tag("logo-white.png", class: "furima-white-logo",size:'200x50'), root_path
-    %p © FURIMA
+= render "home/footer"

--- a/db/migrate/20200805043522_add_devise_to_users.rb
+++ b/db/migrate/20200805043522_add_devise_to_users.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 class AddDeviseToUsers < ActiveRecord::Migration[5.2]
   def self.up
     create_table :users do |t|
@@ -9,47 +8,38 @@ class AddDeviseToUsers < ActiveRecord::Migration[5.2]
       t.string :first_name,           null: false
       t.string :family_name_kana,       null: false
       t.string :first_name_kana,        null: false
-      t.string :birth,             null: false
+      t.date :birth,             null: false
       t.string :email,              null: false, default: ""
       t.string :encrypted_password, null: false, default: ""
       t.string :password_confirmation, null: false, default: ""
-
       ## Recoverable
       t.string   :reset_password_token
       t.datetime :reset_password_sent_at
-
       ## Rememberable
       t.datetime :remember_created_at
-
       ## Trackable
       # t.integer  :sign_in_count, default: 0, null: false
       # t.datetime :current_sign_in_at
       # t.datetime :last_sign_in_at
       # t.string   :current_sign_in_ip
       # t.string   :last_sign_in_ip
-
       ## Confirmable
       # t.string   :confirmation_token
       # t.datetime :confirmed_at
       # t.datetime :confirmation_sent_at
       # t.string   :unconfirmed_email # Only if using reconfirmable
-
       ## Lockable
       # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
       # t.string   :unlock_token # Only if unlock strategy is :email or :both
       # t.datetime :locked_at
-
-
       # Uncomment below if timestamps were not included in your original model.
       # t.timestamps null: false
     end
-
     add_index :users, :email,                unique: true
     add_index :users, :reset_password_token, unique: true
     # add_index :users, :confirmation_token,   unique: true
     # add_index :users, :unlock_token,         unique: true
   end
-
   def self.down
     # By default, we don't want to make any assumption about how to roll back a migration when your
     # model already existed. Please edit below which fields you would like to remove in this migration.


### PR DESCRIPTION
【WHAT】

ログイン画面とユーザー新規登録画面を修正

＞氏名登録の際カタカナが弾かれる
＞ログインページの上部に空欄ができる
＞入力不備時にレイアウトが崩れる
＞生年月日を月と日に分ける
＞ボタンをコーポレートカラーに
＞フッターコードをテンプレートへ

【WHY】

見た目の洗練、値収集のしやすさ向上のため